### PR TITLE
Replace React.createClass with stateless component

### DIFF
--- a/src/svgTemplate.js
+++ b/src/svgTemplate.js
@@ -1,14 +1,12 @@
 var React = require('react');
 
-module.exports = React.createClass({
-    render: function() {
-        var baseProps = {
-            className: '{% className %}',
-            dangerouslySetInnerHTML: {
-                __html: '{% svgElement %}'
-            }
-        };
-        var props = Object.assign({}, baseProps, this.props);
-        return React.createElement('i', props);
-    }
-});
+module.exports = function(props) {
+    const baseProps = {
+        className: '{% className %}',
+        dangerouslySetInnerHTML: {
+            __html: '{% svgElement %}'
+        }
+    };
+
+    return React.createElement('i', Object.assign({}, baseProps, props));
+};


### PR DESCRIPTION
When using this loader with React 15.5.x you should be getting a waring from react in the console saying you should't be using React.createClass anymore.

This pull request solves that problem, removing the need of createClass with stateless component (simple function).

🎉🎉🎉